### PR TITLE
fix: MainAppView.update_slide_list の引数エラーを修正

### DIFF
--- a/src/views/main_app_view.py
+++ b/src/views/main_app_view.py
@@ -499,8 +499,8 @@ class MainAppView(ctk.CTk):
     def update_theme_selection(self, themes: list, selected_theme: str):
         self.side_panel.update_theme_selection(themes, selected_theme)
 
-    def update_slide_list(self, slides: List['SlideData'], current_slide_index: int):
-        self.side_panel.update_slide_list(slides, current_slide_index)
+    def update_slide_list(self, slides: List['SlideData'], current_slide_index: int, slide_images: List[bytes]):
+        self.side_panel.update_slide_list(slides, current_slide_index, slide_images)
 
     def toggle_presentation_mode(self):
         if self.presentation_window is None or not self.presentation_window.winfo_exists():


### PR DESCRIPTION
AppControllerから呼び出される MainAppView.update_slide_list メソッドが、 変更された引数の数（スライド画像リストの追加）に対応していなかったため、
TypeErrorが発生していた問題を修正しました。

MainAppView.update_slide_list が新しい引数を受け取り、
正しく SidePanel.update_slide_list に渡すようにしました。