### PR TITLE
style: スライドサムネイル表示のパディングを縮小

### DIFF
--- a/src/views/main_app_view.py
+++ b/src/views/main_app_view.py
@@ -296,7 +296,7 @@ class SidePanel(ctk.CTkTabview):
 
         # Determine thumbnail width dynamically
         frame_width = self.slides_frame.winfo_width()
-        horizontal_padding = 20  # Total padding (left + right)
+        horizontal_padding = 10  # Total padding (left + right) - Reduced
         min_thumbnail_width = 80
         default_thumbnail_width = 220 # Approx 1.7x of 128
 
@@ -363,7 +363,7 @@ class SidePanel(ctk.CTkTabview):
                     if slide.index == current_slide_index:
                         image_widget.configure(fg_color=("#90CAF9", "#1E88E5")) # Example selected color (light blueish)
 
-                    image_widget.pack(padx=5, pady=5)
+                    image_widget.pack(padx=2, pady=2) # padx/pady Reduced
                     self.slide_buttons.append(image_widget)
 
                 except Exception as e:


### PR DESCRIPTION
SidePanel内のスライドサムネイル表示について、周囲のパディング値を調整し、
よりサムネイルが大きく表示されるようにしました。

- `horizontal_padding` (フレーム内の左右合計パディング) を20から10に縮小。
- 各サムネイルウィジェットの`padx`, `pady` を5から2に縮小。

これにより、表示領域内の余白が減り、サムネイル画像の表示サイズが
相対的に大きくなる効果を期待しています。